### PR TITLE
Add RPC performance test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ All configuration is driven by environment variables mapped in `src/main/resourc
 | `MQTT_PORT` | `1883` | MQTT broker port (8883 for TLS) |
 | `MQTT_SSL_ENABLED` | `false` | Enable MQTT TLS |
 | `DEVICE_API` | `MQTT` | Device protocol: `MQTT`, `HTTP`, or `LWM2M` |
-| `TEST_API` | `device` | Test mode: `device`, `gateway`, or `lwm2m` |
+| `TEST_API` | `device` | Test mode: `device`, `gateway`, `lwm2m`, or `rpc` |
 | `DEVICE_START_IDX` | `0` | First device index |
 | `DEVICE_END_IDX` | `1000` | Last device index |
 | `DEVICE_CREATE_ON_START` | `true` | Create devices before test |
@@ -66,6 +66,15 @@ All configuration is driven by environment variables mapped in `src/main/resourc
 | `WARMUP_ENABLED` | `true` | Run warmup phase before test |
 | `UPDATE_ROOT_RULE_CHAIN` | `false` | Replace TB root rule chain with a counter rule chain during test |
 | `ALARMS_PER_SECOND` | `1` | Alarm messages per second |
+
+### RPC test variables (used when `TEST_API=rpc`)
+
+| Variable | Default | Description |
+|---|---|---|
+| `RPC_TWO_WAY` | `false` | `false` = one-way (fire-and-forget); `true` = two-way (server waits for device response) |
+| `RPC_METHOD` | `setGpio` | RPC method name sent to devices |
+| `MESSAGES_PER_SECOND` | `1000` | RPC requests per second |
+| `DURATION_IN_SECONDS` | `300` | Test duration |
 
 ## Architecture
 
@@ -86,6 +95,7 @@ Concrete executors:
 - `DeviceBaseTestExecutor` → `MqttDeviceAPITest`, `HttpDeviceAPITest`, `Lwm2mDeviceAPITest`
 - `GatewayBaseTestExecutor` → `MqttGatewayAPITest`, `GatewayAPITest`
 - `LwM2MClientBaseTestExecutor` → `Lwm2mDeviceAPITest`
+- `RpcBaseTestExecutor` → `MqttRpcAPITest` (activated by `TEST_API=rpc`)
 
 ### Message Generation
 `MessageGenerator` implementations in `service/msg/`:

--- a/src/main/java/org/thingsboard/tools/service/RpcBaseTestExecutor.java
+++ b/src/main/java/org/thingsboard/tools/service/RpcBaseTestExecutor.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.tools.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.thingsboard.tools.service.rpc.MqttRpcAPITest;
+import org.thingsboard.tools.service.shared.BaseTestExecutor;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Slf4j
+@ConditionalOnProperty(prefix = "test", value = "api", havingValue = "rpc")
+public class RpcBaseTestExecutor extends BaseTestExecutor {
+
+    @Value("${test.exitAfterComplete:true}")
+    boolean exitAfterComplete;
+
+    @Autowired
+    private MqttRpcAPITest rpcAPITest;
+
+    @Override
+    protected void initEntities() throws Exception {
+        if (deviceCreateOnStart) {
+            rpcAPITest.createDevices();
+        }
+
+        if (testEnabled) {
+            rpcAPITest.connectDevices();
+        }
+
+        if (warmupEnabled && testEnabled) {
+            rpcAPITest.warmUpDevices();
+        }
+    }
+
+    @Override
+    protected void runApiTests() throws InterruptedException {
+        rpcAPITest.runApiTests();
+    }
+
+    @Override
+    protected void cleanUpEntities() throws Exception {
+        if (deviceDeleteOnComplete) {
+            rpcAPITest.removeDevices();
+        }
+    }
+
+    @Override
+    protected void waitOtherClients() throws Exception {
+        if (testEnabled) {
+            log.info("RPC test completed. Waiting for other clients to complete!");
+            while (!exitAfterComplete) {
+                try {
+                    log.info("If all clients done, please execute next command: 'kubectl delete statefulset tb-performance-run'");
+                    TimeUnit.SECONDS.sleep(10);
+                } catch (InterruptedException e) {
+                    throw new IllegalStateException("Thread interrupted", e);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/thingsboard/tools/service/rpc/MqttRpcAPITest.java
+++ b/src/main/java/org/thingsboard/tools/service/rpc/MqttRpcAPITest.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.tools.service.rpc;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.util.concurrent.Future;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.thingsboard.mqtt.MqttClient;
+import org.thingsboard.server.common.data.Device;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.tools.service.device.DeviceAPITest;
+import org.thingsboard.tools.service.mqtt.DeviceClient;
+import org.thingsboard.tools.service.shared.BaseMqttAPITest;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@ConditionalOnProperty(prefix = "test", value = "api", havingValue = "rpc")
+public class MqttRpcAPITest extends BaseMqttAPITest implements DeviceAPITest {
+
+    private static final byte[] RPC_RESPONSE = "{\"success\":true}".getBytes(StandardCharsets.UTF_8);
+    private static final String RPC_REQUEST_PREFIX = "v1/devices/me/rpc/request/";
+
+    @Value("${rpc.twoWay:false}")
+    private boolean rpcTwoWay;
+
+    @Value("${rpc.method:setGpio}")
+    private String rpcMethod;
+
+    /** Map of device name → DeviceId for REST API calls */
+    private final Map<String, DeviceId> deviceIdMap = new ConcurrentHashMap<>();
+
+    // === DeviceAPITest lifecycle ===
+
+    @Override
+    public void createDevices() throws Exception {
+        createDevices(true);
+    }
+
+    @Override
+    public void removeDevices() throws Exception {
+        removeEntities(devices.stream().map(Device::getId).collect(Collectors.toList()), "devices");
+    }
+
+    @Override
+    public void connectDevices() throws InterruptedException {
+        AtomicInteger totalConnectedCount = new AtomicInteger();
+        List<String> pack = null;
+        List<String> devicesNames = buildDeviceNames();
+
+        for (String device : devicesNames) {
+            if (pack == null) {
+                pack = new ArrayList<>(warmUpPackSize);
+            }
+            pack.add(device);
+            if (pack.size() == warmUpPackSize) {
+                connectDevices(pack, totalConnectedCount, false);
+                Thread.sleep(1 + random.nextInt(100));
+                pack = null;
+            }
+        }
+        if (pack != null && !pack.isEmpty()) {
+            connectDevices(pack, totalConnectedCount, false);
+        }
+
+        subscribeToRpcRequests();
+        mapDevicesToClients();
+    }
+
+    @Override
+    public void generationX509() {
+    }
+
+    // === Test execution ===
+
+    @Override
+    public void runApiTests() throws InterruptedException {
+        buildDeviceIdMap();
+        log.info("Starting RPC performance test: {} devices, {} RPS, {}s duration, twoWay={}",
+                deviceClients.size(), testMessagesPerSecond, testDurationInSec, rpcTwoWay);
+        super.runApiTests(deviceClients.size());
+    }
+
+    @Override
+    protected void runApiTestIteration(int iteration, AtomicInteger totalSuccessPublishedCount,
+                                       AtomicInteger totalFailedPublishedCount, CountDownLatch testDurationLatch) {
+        try {
+            log.info("[{}] Starting RPC iteration for {} devices...", iteration, deviceClients.size());
+            AtomicInteger successCount = new AtomicInteger();
+            AtomicInteger failedCount = new AtomicInteger();
+            CountDownLatch iterationLatch = new CountDownLatch(testMessagesPerSecond);
+
+            ObjectNode requestBody = buildRpcRequestBody();
+            int deviceCount = deviceClients.size();
+
+            for (int i = 0; i < testMessagesPerSecond; i++) {
+                int idx = (iteration * testMessagesPerSecond + i) % deviceCount;
+                DeviceClient client = deviceClients.get(idx);
+                DeviceId deviceId = deviceIdMap.get(client.getDeviceName());
+
+                if (deviceId == null) {
+                    log.warn("[{}] No deviceId for {}, skipping", iteration, client.getDeviceName());
+                    iterationLatch.countDown();
+                    continue;
+                }
+
+                restClientService.getWorkers().submit(() -> {
+                    try {
+                        if (rpcTwoWay) {
+                            restClientService.getRestClient().handleTwoWayDeviceRPCRequest(deviceId, requestBody);
+                        } else {
+                            restClientService.getRestClient().handleOneWayDeviceRPCRequest(deviceId, requestBody);
+                        }
+                        totalSuccessPublishedCount.incrementAndGet();
+                        successCount.incrementAndGet();
+                        log.debug("[{}] RPC sent to device: {}", iteration, client.getDeviceName());
+                    } catch (Exception e) {
+                        totalFailedPublishedCount.incrementAndGet();
+                        failedCount.incrementAndGet();
+                        log.error("[{}] RPC failed for device {}: {}", iteration, client.getDeviceName(), e.getMessage());
+                    } finally {
+                        iterationLatch.countDown();
+                    }
+                });
+            }
+
+            iterationLatch.await();
+            log.info("[{}] RPC iteration complete. Success: {}, Failed: {}",
+                    iteration, successCount.get(), failedCount.get());
+        } catch (Throwable t) {
+            log.warn("[{}] Failed to process RPC iteration", iteration, t);
+        } finally {
+            testDurationLatch.countDown();
+        }
+    }
+
+    // === BaseMqttAPITest required implementations ===
+
+    @Override
+    protected String getWarmUpTopic() {
+        return "v1/devices/me/telemetry";
+    }
+
+    @Override
+    protected byte[] getData(String deviceName) {
+        return "{\"warmup\":1}".getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    protected String getTestTopic() {
+        return "v1/devices/me/telemetry";
+    }
+
+    @Override
+    protected void logSuccessTestMessage(int iteration, DeviceClient client) {
+        log.debug("[{}] RPC sent to {}", iteration, client.getDeviceName());
+    }
+
+    @Override
+    protected void logFailureTestMessage(int iteration, DeviceClient client, Future<?> future) {
+        log.warn("[{}] RPC failed for {}: {}", iteration, client.getDeviceName(), future.cause().getMessage());
+    }
+
+    // === Private helpers ===
+
+    private List<String> buildDeviceNames() {
+        if (!devices.isEmpty()) {
+            return devices.stream().map(Device::getName).collect(Collectors.toList());
+        }
+        List<String> names = new ArrayList<>();
+        for (int i = deviceStartIdx; i < deviceEndIdx; i++) {
+            names.add(getToken(false, i));
+        }
+        return names;
+    }
+
+    private void subscribeToRpcRequests() throws InterruptedException {
+        log.info("Subscribing {} devices to RPC requests...", mqttClients.size());
+        CountDownLatch latch = new CountDownLatch(mqttClients.size());
+
+        for (MqttClient client : mqttClients) {
+            client.on("v1/devices/me/rpc/request/+", (topic, payload) -> {
+                String requestId = topic.substring(topic.lastIndexOf('/') + 1);
+                String responseTopic = "v1/devices/me/rpc/response/" + requestId;
+                client.publish(responseTopic, Unpooled.wrappedBuffer(RPC_RESPONSE), MqttQoS.AT_MOST_ONCE);
+                return CompletableFuture.completedFuture(null);
+            }, MqttQoS.AT_MOST_ONCE).addListener(f -> latch.countDown());
+        }
+
+        boolean allSubscribed = latch.await(30, TimeUnit.SECONDS);
+        if (!allSubscribed) {
+            log.warn("Not all devices subscribed to RPC topics within 30s, continuing anyway...");
+        }
+        log.info("RPC subscriptions ready for {} devices", mqttClients.size());
+    }
+
+    private void mapDevicesToClients() {
+        for (MqttClient mqttClient : mqttClients) {
+            DeviceClient client = new DeviceClient();
+            client.setMqttClient(mqttClient);
+            client.setDeviceName(mqttClient.getClientConfig().getUsername());
+            deviceClients.add(client);
+        }
+        log.info("Sorting device clients...");
+        deviceClients.sort(Comparator.comparing(DeviceClient::getDeviceName));
+        log.info("Shuffling device clients...");
+        Collections.shuffle(deviceClients, random);
+    }
+
+    private void buildDeviceIdMap() {
+        for (Device device : devices) {
+            deviceIdMap.put(device.getName(), device.getId());
+        }
+        if (deviceIdMap.isEmpty()) {
+            log.info("Device list empty, looking up device IDs via REST...");
+            for (DeviceClient client : deviceClients) {
+                restClientService.getRestClient().findDevice(client.getDeviceName())
+                        .ifPresent(d -> deviceIdMap.put(d.getName(), d.getId()));
+            }
+        }
+        log.info("Device ID map built for {} devices", deviceIdMap.size());
+    }
+
+    private ObjectNode buildRpcRequestBody() {
+        ObjectNode body = mapper.createObjectNode();
+        body.put("method", rpcMethod);
+        body.putObject("params").put("value", 1);
+        return body;
+    }
+}

--- a/src/main/resources/tb-ce-performance-tests.yml
+++ b/src/main/resources/tb-ce-performance-tests.yml
@@ -187,3 +187,8 @@ test:
     aps: "${ALARMS_PER_SECOND:1}"
   exitAfterComplete: "${EXIT_AFTER_COMPLETE:true}" # this useful for kubernetes statefulset setup
   seed: "${SEED:0}" # random seed to provide reproducible random order on each run
+rpc:
+  # false = one-way RPC (server sends, no response required); true = two-way RPC (server waits for device response)
+  twoWay: "${RPC_TWO_WAY:false}"
+  # RPC method name sent to devices
+  method: "${RPC_METHOD:setGpio}"


### PR DESCRIPTION
## Summary

Adds a new `TEST_API=rpc` mode that stress-tests ThingsBoard's server-side RPC subsystem by driving RPC commands to many concurrent MQTT-connected devices.

## How it works

1. **Connect**: Connects N MQTT device clients, each subscribing to `v1/devices/me/rpc/request/+`
2. **Warmup**: Sends an initial telemetry message per device to stabilize connections
3. **Test loop**: Every second, sends `MESSAGES_PER_SECOND` RPC requests to devices via the ThingsBoard REST API (`POST /api/rpc/oneway/{deviceId}` or `twoway/{deviceId}`)
4. **Device response**: Each device immediately publishes a response to `v1/devices/me/rpc/response/{requestId}`
5. **Metrics**: Logs success/failure counts per iteration and aggregate totals

## Two modes

| Mode | Env var | Behavior |
|---|---|---|
| One-way (default) | `RPC_TWO_WAY=false` | Fire-and-forget — server enqueues the command, returns immediately. Tests max RPC throughput. |
| Two-way | `RPC_TWO_WAY=true` | Server blocks until the device responds or times out. Tests full round-trip latency under load. |

## New files

- `service/rpc/MqttRpcAPITest.java` — MQTT RPC test implementation
- `service/RpcBaseTestExecutor.java` — executor activated by `TEST_API=rpc`

## Configuration

| Variable | Default | Description |
|---|---|---|
| `TEST_API` | `device` | Set to `rpc` |
| `RPC_TWO_WAY` | `false` | Enable two-way RPC (blocks waiting for device response) |
| `RPC_METHOD` | `setGpio` | RPC method name sent to devices |
| `MESSAGES_PER_SECOND` | `1000` | RPC requests per second |
| `DURATION_IN_SECONDS` | `300` | Test duration |

## Example

```bash
docker run -it --rm --network host \
  --env REST_URL=http://127.0.0.1:8080 \
  --env MQTT_HOST=127.0.0.1 \
  --env TEST_API=rpc \
  --env DEVICE_END_IDX=1000 \
  --env MESSAGES_PER_SECOND=500 \
  --env DURATION_IN_SECONDS=300 \
  --env RPC_TWO_WAY=false \
  thingsboard/tb-ce-performance-test:latest
```

> **Note for two-way RPC**: each in-flight request occupies a worker thread while waiting for the device to respond. The default worker pool (16 threads) caps concurrent two-way RPC calls. Reduce `MESSAGES_PER_SECOND` or increase `REST_POOL_SIZE` for higher two-way throughput.